### PR TITLE
Add fadeOnEntry flag to scene JSON for fade-to-black on navigation

### DIFF
--- a/skse/src/Core/Thread.cpp
+++ b/skse/src/Core/Thread.cpp
@@ -184,9 +184,24 @@ namespace Threading {
     void Thread::Navigate(std::string sceneId) {
         for (auto& nav : m_currentNode->navigations) {
             if (sceneId == nav.nodes.front()->scene_id) {
-                ChangeNode(nav.nodes.front());
+                if (playerThread && nav.nodes.front()->fadeOnEntry) {
+                    Graph::Node* node = nav.nodes.front();
+                    std::thread fadeThread = std::thread([node] {
+                        GameAPI::GameCamera::fadeToBlack(1);
+                        std::this_thread::sleep_for(std::chrono::milliseconds(700));
+                        Thread* thread = ThreadManager::GetSingleton()->getPlayerThread();
+                        if (thread) {
+                            thread->ChangeNode(node);
+                        }
+                        std::this_thread::sleep_for(std::chrono::milliseconds(550));
+                        GameAPI::GameCamera::fadeFromBlack(1);
+                    });
+                    fadeThread.detach();
+                } else {
+                    ChangeNode(nav.nodes.front());
+                }
             }
-        }      
+        }
     }
 
     void Thread::ChangeNode(Graph::Node* a_node) {

--- a/skse/src/Core/Thread.cpp
+++ b/skse/src/Core/Thread.cpp
@@ -181,22 +181,25 @@ namespace Threading {
         return Alignment::Alignments::getActorAlignment(alignmentKey, m_currentNode, index);
     }
 
+    void Thread::fadeAndChangeNode(Graph::Node* node) {
+        std::thread fadeThread = std::thread([node] {
+            GameAPI::GameCamera::fadeToBlack(1);
+            std::this_thread::sleep_for(std::chrono::milliseconds(700));
+            Thread* thread = ThreadManager::GetSingleton()->getPlayerThread();
+            if (thread) {
+                thread->ChangeNode(node);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(550));
+            GameAPI::GameCamera::fadeFromBlack(1);
+        });
+        fadeThread.detach();
+    }
+
     void Thread::Navigate(std::string sceneId) {
         for (auto& nav : m_currentNode->navigations) {
             if (sceneId == nav.nodes.front()->scene_id) {
                 if (playerThread && nav.nodes.front()->fadeOnEntry) {
-                    Graph::Node* node = nav.nodes.front();
-                    std::thread fadeThread = std::thread([node] {
-                        GameAPI::GameCamera::fadeToBlack(1);
-                        std::this_thread::sleep_for(std::chrono::milliseconds(700));
-                        Thread* thread = ThreadManager::GetSingleton()->getPlayerThread();
-                        if (thread) {
-                            thread->ChangeNode(node);
-                        }
-                        std::this_thread::sleep_for(std::chrono::milliseconds(550));
-                        GameAPI::GameCamera::fadeFromBlack(1);
-                    });
-                    fadeThread.detach();
+                    fadeAndChangeNode(nav.nodes.front());
                 } else {
                     ChangeNode(nav.nodes.front());
                 }

--- a/skse/src/Core/Thread.cpp
+++ b/skse/src/Core/Thread.cpp
@@ -198,11 +198,7 @@ namespace Threading {
     void Thread::Navigate(std::string sceneId) {
         for (auto& nav : m_currentNode->navigations) {
             if (sceneId == nav.nodes.front()->scene_id) {
-                if (playerThread && nav.nodes.front()->fadeOnEntry) {
-                    fadeAndChangeNode(nav.nodes.front());
-                } else {
-                    ChangeNode(nav.nodes.front());
-                }
+                warpTo(nav.nodes.front(), nav.nodes.front()->fadeOnEntry);
             }
         }
     }

--- a/skse/src/Core/Thread.h
+++ b/skse/src/Core/Thread.h
@@ -249,6 +249,7 @@ namespace Threading {
         int nodeQueueCooldown = 0;
         std::queue<Graph::SequenceEntry> nodeQueue;
 
+        void fadeAndChangeNode(Graph::Node* node);
         void clearNodeQueue();
 #pragma endregion
 

--- a/skse/src/Core/Thread/ThreadNavigation.cpp
+++ b/skse/src/Core/Thread/ThreadNavigation.cpp
@@ -146,7 +146,7 @@ namespace Threading {
 
         std::vector<Graph::SequenceEntry> nodes = m_currentNode->getRoute(MCM::MCMTable::navigationDistanceMax(), getActorConditions(), node);
         if (nodes.empty()) {
-            warpTo(node, MCM::MCMTable::useAutoModeFades());
+            warpTo(node, node->fadeOnEntry);
             nodeQueueCooldown = duration + 1000;
         } else {
             nodes.back().duration = duration;
@@ -154,7 +154,22 @@ namespace Threading {
                 nodeQueue.push(nodes[i]);
             }
             nodeQueueCooldown = nodes.front().duration;
-            ChangeNode(nodes.front().node);
+            if (playerThread && nodes.front().node->fadeOnEntry) {
+                Graph::Node* firstNode = nodes.front().node;
+                std::thread fadeThread = std::thread([firstNode] {
+                    GameAPI::GameCamera::fadeToBlack(1);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(700));
+                    Thread* thread = ThreadManager::GetSingleton()->getPlayerThread();
+                    if (thread) {
+                        thread->ChangeNode(firstNode);
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(550));
+                    GameAPI::GameCamera::fadeFromBlack(1);
+                });
+                fadeThread.detach();
+            } else {
+                ChangeNode(nodes.front().node);
+            }
         }
     }
 

--- a/skse/src/Core/Thread/ThreadNavigation.cpp
+++ b/skse/src/Core/Thread/ThreadNavigation.cpp
@@ -146,7 +146,7 @@ namespace Threading {
 
         std::vector<Graph::SequenceEntry> nodes = m_currentNode->getRoute(MCM::MCMTable::navigationDistanceMax(), getActorConditions(), node);
         if (nodes.empty()) {
-            warpTo(node, node->fadeOnEntry);
+            warpTo(node, MCM::MCMTable::useAutoModeFades() || node->fadeOnEntry);
             nodeQueueCooldown = duration + 1000;
         } else {
             nodes.back().duration = duration;
@@ -154,19 +154,8 @@ namespace Threading {
                 nodeQueue.push(nodes[i]);
             }
             nodeQueueCooldown = nodes.front().duration;
-            if (playerThread && nodes.front().node->fadeOnEntry) {
-                Graph::Node* firstNode = nodes.front().node;
-                std::thread fadeThread = std::thread([firstNode] {
-                    GameAPI::GameCamera::fadeToBlack(1);
-                    std::this_thread::sleep_for(std::chrono::milliseconds(700));
-                    Thread* thread = ThreadManager::GetSingleton()->getPlayerThread();
-                    if (thread) {
-                        thread->ChangeNode(firstNode);
-                    }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(550));
-                    GameAPI::GameCamera::fadeFromBlack(1);
-                });
-                fadeThread.detach();
+            if (playerThread && (MCM::MCMTable::useAutoModeFades() || nodes.front().node->fadeOnEntry)) {
+                fadeAndChangeNode(nodes.front().node);
             } else {
                 ChangeNode(nodes.front().node);
             }

--- a/skse/src/Graph/GraphTable/GraphTableSetupNodes.cpp
+++ b/skse/src/Graph/GraphTable/GraphTableSetupNodes.cpp
@@ -245,6 +245,14 @@ namespace Graph {
                 }
             }
 
+            if (json.contains("fadeOnEntry")) {
+                if (json["fadeOnEntry"].is_boolean()) {
+                    node->fadeOnEntry = json["fadeOnEntry"];
+                } else {
+                    logger::warn("fadeOnEntry property of scene {} isn't a boolean", node->scene_id);
+                }
+            }
+
             if (json.contains("furniture")) {
                 if (json["furniture"].is_string()) {
                     node->furnitureType = Furniture::FurnitureTable::getFurnitureType(json["furniture"]);

--- a/skse/src/Graph/Node.h
+++ b/skse/src/Graph/Node.h
@@ -47,6 +47,7 @@ namespace Graph {
         int animationLengthMs = 0;
         bool hasIdleSpeed = false;
         bool noRandomSelection = false;
+        bool fadeOnEntry = false;
         Furniture::FurnitureType* furnitureType = nullptr;
         std::unordered_map<std::string, std::string> autoTransitions;
         std::vector<NodeTag> tags;


### PR DESCRIPTION
## Summary

Adds a boolean `fadeOnEntry` field to scene JSON that controls whether a 
fade-to-black transition plays when navigating to that scene.

## Motivation

Some scenes have animation blending artifacts that are visible during 
direct transitions. https://file.garden/aD8d9pSm3U0NqMYA/fade/fade%202.gif
The `fadeOnEntry` flag allows mod authors to opt in 
to a fade-to-black on a per-scene basis to hide these artifacts. https://file.garden/aD8d9pSm3U0NqMYA/fade/fade%201.gif

## Changes

- `Graph/Node.h`: Add `fadeOnEntry` field (default: `false`)
- `Graph/GraphTable/GraphTableSetupNodes.cpp`: Parse `fadeOnEntry` from scene JSON
- `Core/Thread.cpp`: Apply fade in `Navigate()` via existing `warpTo()` when `fadeOnEntry` is true
- `Core/Thread/ThreadNavigation.cpp`: Apply fade in `navigateTo()` when `fadeOnEntry` is true, respecting the existing MCM auto-mode fade setting

## Backwards Compatibility

Fully backwards compatible. Scenes without the flag behave exactly as before (`fadeOnEntry` defaults to `false`).

## Usage

In scene JSON:
```json
"fadeOnEntry": true