### PR TITLE
Fix stale OStim UI task dereferencing removed thread

### DIFF
--- a/skse/src/UI/UIState.cpp
+++ b/skse/src/UI/UIState.cpp
@@ -87,7 +87,9 @@ namespace UI {
         if (currentThread != thread) return;
         
         currentNode = node;
-        SKSE::GetTaskInterface()->AddTask([node]() {
+        SKSE::GetTaskInterface()->AddTask([thread]() {
+            if (UIState::GetSingleton()->currentThread != thread) return;
+            
             UI::Align::AlignMenu::GetMenu()->NodeChanged();
             UI::Scene::SceneMenu::GetMenu()->UpdateMenuData();
             UI::Scene::SceneMenu::GetMenu()->UpdateSpeed();


### PR DESCRIPTION
This fixes a race condition in `UIState::NodeChanged()` where a queued UI task can execute after its associated OStim thread has already been removed or replaced.

The issue has now been reproduced on both OStim 7.4.0.3 and 7.5.0.2. In the latest crash, `AlignMenu::NodeChanged()` called `LoadCurrentAlignment()`, which then called `Thread::getActorAlignment()` with a null `currentThread`. This caused an access violation while attempting to read from `0xB8`. The call stack again shows the failure occurring through the queued OStim UI update path.

`NodeChanged()` validates `currentThread == thread` before queuing the task, but that state can change before the task executes. `HandleThreadRemoved()` may set `currentThread` to `nullptr` during that interval.

The change revalidates that the queued task's thread is still the active thread immediately before performing the UI update. If the thread has been removed or replaced, the stale task is discarded instead of allowing `AlignMenu` to dereference an invalid `currentThread`.

The latest reproduction occurred on OStim 7.5.0.2.